### PR TITLE
Add graph filter params

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ healthcheck >= 1.3.3
 iso8601 >= 0.1.12
 pytz >= 2019.1
 click >= 7.0
+luqum == 0.8.0

--- a/synprov/controllers/activities_controller.py
+++ b/synprov/controllers/activities_controller.py
@@ -94,7 +94,8 @@ def delete_activity_used(
 def get_activities_graph(
     sort_by='created_at',
     order='desc',
-    limit=3
+    limit=3,
+    q='*:*'
 ):  # noqa: E501
     """Get provenance graph
 
@@ -106,13 +107,16 @@ def get_activities_graph(
     :type order: str
     :param limit: maximum number of connected activities to return
     :type limit: int
+    :param q: filter results using Lucene Query Syntax in the format of propertyName:value, propertyName:[num1 TO num2] and date range format, propertyName:[yyyyMMdd TO yyyyMMdd]
+    :type q: str
 
     :rtype: Neo4jGraph
     """
     return controller.get_activities_graph(
         sort_by=sort_by,
         order=order,
-        limit=limit
+        limit=limit,
+        q=q
     )
 
 
@@ -120,7 +124,8 @@ def get_agent_subgraph(
     user_id,
     sort_by='created_at',
     order='desc',
-    limit=3
+    limit=3,
+    q='*:*'
 ):  # noqa: E501
     """Get subgraph connected to an agent
 
@@ -134,6 +139,8 @@ def get_agent_subgraph(
     :type order: str
     :param limit: maximum number of connected activities to return
     :type limit: int
+    :param q: filter results using Lucene Query Syntax in the format of propertyName:value, propertyName:[num1 TO num2] and date range format, propertyName:[yyyyMMdd TO yyyyMMdd]
+    :type q: str
 
     :rtype: Neo4jGraph
     """
@@ -141,7 +148,8 @@ def get_agent_subgraph(
         user_id=user_id,
         sort_by=sort_by,
         order=order,
-        limit=limit
+        limit=limit,
+        q=q
     )
 
 
@@ -150,7 +158,8 @@ def get_reference_subgraph(
     direction='down',
     sort_by='created_at',
     order='desc',
-    limit=3
+    limit=3,
+    q='*:*'
 ):  # noqa: E501
     """Get subgraph connected to an entity
 
@@ -166,6 +175,8 @@ def get_reference_subgraph(
     :type order: str
     :param limit: maximum number of connected activities to return
     :type limit: int
+    :param q: filter results using Lucene Query Syntax in the format of propertyName:value, propertyName:[num1 TO num2] and date range format, propertyName:[yyyyMMdd TO yyyyMMdd]
+    :type q: str
 
     :rtype: Neo4jGraph
     """
@@ -174,5 +185,6 @@ def get_reference_subgraph(
         direction=direction,
         sort_by=sort_by,
         order=order,
-        limit=limit
+        limit=limit,
+        q=q
     )

--- a/synprov/graph/controllers/activities_controller.py
+++ b/synprov/graph/controllers/activities_controller.py
@@ -3,12 +3,21 @@ import six
 import uuid
 import humps
 import json
+import logging
 
 from py2neo import Node, NodeMatcher
+from luqum.parser import parser
 
+from synprov.models.activity import Activity
 from synprov.config import neo4j_connection as graph
 from synprov.graph import ActivityBuilder, ActivityEditor
-from synprov.util import neo4j_to_d3, neo4j_export, convert_keys
+from synprov.util import neo4j_to_d3, neo4j_export, convert_keys, quote_string
+
+
+logger = logging.getLogger(__name__)
+
+
+ATTR_MAP = dict([[v, k] for k, v in Activity().attribute_map.items()])
 
 
 def add_activity_used(
@@ -101,7 +110,12 @@ def delete_activity_used(
     )
 
 
-def get_activities_graph(sort_by=None, order=None, limit=None):  # noqa: E501
+def get_activities_graph(
+    sort_by='created_at',
+    order='desc',
+    limit=3,
+    q='*:*'
+):  # noqa: E501
     """Get provenance graph
 
     Retrieve all nodes and relationships in the graph that pass filters.  # noqa: E501
@@ -112,12 +126,22 @@ def get_activities_graph(sort_by=None, order=None, limit=None):  # noqa: E501
     :type order: str
     :param limit: maximum number of connected activities to return
     :type limit: int
+    :param q: filter results using Lucene Query Syntax in the format of propertyName:value, propertyName:[num1 TO num2] and date range format, propertyName:[yyyyMMdd TO yyyyMMdd]
+    :type q: str
 
     :rtype: Neo4jGraph
     """
+    filter_properties = ''
+    if q != '*:*':
+        tree = parser.parse(q)
+        key = ATTR_MAP[tree.name]
+        val = quote_string(tree.children[0].value)
+        filter_properties = f' {{{key}: {val}}}'
+    logger.info(f"FILTER PROPS: {filter_properties}")
+
     query_base = (
         '''
-        MATCH (s:Activity)
+        MATCH (s:Activity{filter})
         WITH s
         ORDER BY s.{key}{dir}
         WITH collect(s) as activities
@@ -128,7 +152,8 @@ def get_activities_graph(sort_by=None, order=None, limit=None):  # noqa: E501
     ).format(
         key=sort_by,
         dir=(' ' + order.upper()) if order == 'desc' else '',
-        lim=limit
+        lim=limit,
+        filter=filter_properties
     )
 
     results = graph.run(
@@ -141,7 +166,8 @@ def get_agent_subgraph(
     user_id,
     sort_by='created_at',
     order='desc',
-    limit=3
+    limit=3,
+    q='*:*'
 ):  # noqa: E501
     """Get subgraph connected to an agent
 
@@ -155,12 +181,22 @@ def get_agent_subgraph(
     :type order: str
     :param limit: maximum number of connected activities to return
     :type limit: int
+    :param q: filter results using Lucene Query Syntax in the format of propertyName:value, propertyName:[num1 TO num2] and date range format, propertyName:[yyyyMMdd TO yyyyMMdd]
+    :type q: str
 
     :rtype: Neo4jGraph
     """
+    filter_properties = ''
+    if q != '*:*':
+        tree = parser.parse(q)
+        key = ATTR_MAP[tree.name]
+        val = quote_string(tree.children[0].value)
+        filter_properties = f' {{{key}: {val}}}'
+    logger.info(f"FILTER PROPS: {filter_properties}")
+
     query_base = (
         '''
-        MATCH (t:Agent {{user_id: {{user_id}}}})<-[r:WASASSOCIATEDWITH]-(s:Activity)
+        MATCH (t:Agent {{user_id: {{user_id}}}})<-[r:WASASSOCIATEDWITH]-(s:Activity{filter})
         WITH s
         ORDER BY s.{key}{dir}
         WITH collect(s) as activities
@@ -171,7 +207,8 @@ def get_agent_subgraph(
     ).format(
         key=sort_by,
         dir=(' ' + order.upper()) if order == 'desc' else '',
-        lim=limit
+        lim=limit,
+        filter=filter_properties
     )
 
     results = graph.run(
@@ -186,7 +223,8 @@ def get_reference_subgraph(
     direction='down',
     sort_by='created_at',
     order='desc',
-    limit=3
+    limit=3,
+    q='*:*'
 ):  # noqa: E501
     """Get subgraph connected to an entity
 
@@ -202,16 +240,26 @@ def get_reference_subgraph(
     :type order: str
     :param limit: maximum number of connected activities to return
     :type limit: int
+    :param q: filter results using Lucene Query Syntax in the format of propertyName:value, propertyName:[num1 TO num2] and date range format, propertyName:[yyyyMMdd TO yyyyMMdd]
+    :type q: str
 
     :rtype: Neo4jGraph
     """
+    filter_properties = ''
+    if q != '*:*':
+        tree = parser.parse(q)
+        key = ATTR_MAP[tree.name]
+        val = quote_string(tree.children[0].value)
+        filter_properties = f' {{{key}: {val}}}'
+    logger.info(f"FILTER PROPS: {filter_properties}")
+
     direction_rels = {
         'up': '-[r:WASGENERATEDBY]->',
         'down': '<-[r:USED]-'
     }
     query_base = (
         '''
-        MATCH (t:Reference {{target_id: {{target_id}}}}){dir_rel}(s:Activity)
+        MATCH (t:Reference {{target_id: {{target_id}}}}){dir_rel}(s:Activity{filter})
         WITH s
         ORDER BY s.{key}{dir}
         WITH collect(s) as activities
@@ -223,7 +271,8 @@ def get_reference_subgraph(
         dir_rel=direction_rels[direction],
         key=sort_by,
         dir=(' ' + order.upper()) if order == 'desc' else '',
-        lim=limit
+        lim=limit,
+        filter=filter_properties
     )
 
     results = graph.run(

--- a/synprov/openapi/openapi.yaml
+++ b/synprov/openapi/openapi.yaml
@@ -76,6 +76,7 @@ paths:
       - $ref: '#/components/parameters/sortParam'
       - $ref: '#/components/parameters/orderParam'
       - $ref: '#/components/parameters/limitParam'
+      - $ref: '#/components/parameters/filterParam'
       responses:
         200:
           $ref: '#/components/responses/200GraphFound'
@@ -161,6 +162,7 @@ paths:
       - $ref: '#/components/parameters/sortParam'
       - $ref: '#/components/parameters/orderParam'
       - $ref: '#/components/parameters/limitParam'
+      - $ref: '#/components/parameters/filterParam'
       responses:
         200:
           $ref: '#/components/responses/200GraphFound'
@@ -187,6 +189,7 @@ paths:
       - $ref: '#/components/parameters/sortParam'
       - $ref: '#/components/parameters/orderParam'
       - $ref: '#/components/parameters/limitParam'
+      - $ref: '#/components/parameters/filterParam'
       responses:
         200:
           $ref: '#/components/responses/200GraphFound'
@@ -375,6 +378,18 @@ components:
         - created_at
         type: string
       style: form
+    filterParam:
+      description: >-
+        filter results using Lucene Query Syntax in the format of
+        propertyName:value, propertyName:[num1 TO num2] and date
+        range format, propertyName:[yyyyMMdd TO yyyyMMdd]
+      explode: false
+      in: query
+      name: q
+      required: false
+      schema:
+        type: string
+        default: '*:*'
     orderParam:
       description: sort order (ascending or descending)
       explode: true

--- a/synprov/util.py
+++ b/synprov/util.py
@@ -172,6 +172,14 @@ def convert_keys(obj):
         return obj
 
 
+def quote_string(string):
+    try:
+        json.loads(string)
+    except json.JSONDecodeError:
+        string = json.dumps(string)
+    return string
+
+
 def get_datetime(now=None):
     if now is None:
         now = datetime.datetime.now()


### PR DESCRIPTION
This PR adds the `q` parameter to all `/graph` endpoints so that clients can request a specific subgraph based on node attributes. The parameter nominally supports Lucene Query Syntax for search/filter operations, but the current implementation only works with single key-value pairs.