### PR TITLE
Add endpoint to get activity object(s)

### DIFF
--- a/synprov/controllers/activities_controller.py
+++ b/synprov/controllers/activities_controller.py
@@ -1,6 +1,7 @@
 import connexion
 import six
 
+from synprov.models import Activity  # noqa: E501
 from synprov.models import ActivityForm  # noqa: E501
 from synprov.models import Neo4jGraph  # noqa: E501
 from synprov.models import Node  # noqa: E501
@@ -146,6 +147,43 @@ def get_agent_subgraph(
     """
     return controller.get_agent_subgraph(
         user_id=user_id,
+        sort_by=sort_by,
+        order=order,
+        limit=limit,
+        q=q
+    )
+
+
+def get_reference_activities(
+    target_id,
+    direction='down',
+    sort_by='created_at',
+    order='desc',
+    limit=3,
+    q='*:*'
+):  # noqa: E501
+    """Get subgraph connected to an entity
+
+    Retrieve the Activity objects in a neighborhood around a specified entity.  # noqa: E501
+
+    :param target_id: entity ID
+    :type target_id: str
+    :param direction: direction in which to collect connected activities
+    :type direction: str
+    :param sort_by: logic by which to sort matched activities
+    :type sort_by: str
+    :param order: sort order (ascending or descending)
+    :type order: str
+    :param limit: maximum number of connected activities to return
+    :type limit: int
+    :param q: filter results using Lucene Query Syntax in the format of propertyName:value, propertyName:[num1 TO num2] and date range format, propertyName:[yyyyMMdd TO yyyyMMdd]
+    :type q: str
+
+    :rtype: List[Activity]
+    """
+    return controller.get_reference_activities(
+        target_id=target_id,
+        direction=direction,
         sort_by=sort_by,
         order=order,
         limit=limit,

--- a/synprov/openapi/openapi.yaml
+++ b/synprov/openapi/openapi.yaml
@@ -197,6 +197,33 @@ paths:
       tags:
       - Activities
       x-openapi-router-controller: synprov.controllers.activities_controller
+  /activities/byReference/{targetId}:
+    get:
+      description: |
+        Retrieve the Activity objects in a neighborhood around a specified entity.
+      operationId: get_reference_activities
+      parameters:
+      - description: entity ID
+        explode: false
+        in: path
+        name: targetId
+        required: true
+        schema:
+          type: string
+        example: resource0
+        style: simple
+      - $ref: '#/components/parameters/directionParam'
+      - $ref: '#/components/parameters/sortParam'
+      - $ref: '#/components/parameters/orderParam'
+      - $ref: '#/components/parameters/limitParam'
+      - $ref: '#/components/parameters/filterParam'
+      responses:
+        200:
+          $ref: '#/components/responses/200ActivitiesFound'
+      summary: Get subgraph connected to an entity
+      tags:
+      - Activities
+      x-openapi-router-controller: synprov.controllers.activities_controller
 components:
   examples:
     activityNode:
@@ -323,6 +350,14 @@ components:
             # oneOf:
             #   - $ref: '#/components/schemas/D3Graph'
             $ref: '#/components/schemas/Neo4jGraph'
+    200ActivitiesFound:
+      description: Found requested Activities.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Activity'
     404NotFound:
       description: The specified resource was not found.
   parameters:

--- a/synprov/util.py
+++ b/synprov/util.py
@@ -247,6 +247,10 @@ def _convert_relationship(neo4j_rel):
     }
 
 
+def node_to_dict(neo4j_node):
+    return convert_keys(dict(neo4j_node))
+
+
 def is_open(ip, port):
    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
    try:


### PR DESCRIPTION
This PR adds a path `/activities/byReference/{targetId}`, allowing a client to retrieve an array of `Activity` _objects_ connected to a reference/entity, instead the full subgraph.